### PR TITLE
Add interactive folium map

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,9 @@
 import streamlit as st
 import pandas as pd
 import geopandas as gpd
-import matplotlib.pyplot as plt
 from shapely.geometry import Point
+import folium
+from streamlit_folium import st_folium
 
 # === load your schools and addresses
 @st.cache_data
@@ -10,7 +11,7 @@ def load_schools():
     return pd.read_csv("https://raw.githubusercontent.com/alanrrz/la_buffer_app_clean/ab73deb13c0a02107f43001161ab70891630a9c7/schools.csv")
 
 st.title("📍 Construction Impact Map Generator")
-st.caption("Generate a black & white map with a red impact zone & entrance marker")
+st.caption("Generate an interactive map with a red impact zone & entrance marker")
 
 schools = load_schools()
 schools.columns = schools.columns.str.strip()
@@ -23,28 +24,40 @@ if st.button("Generate Map"):
     with st.spinner("Generating map…"):
         row = schools[schools["LABEL"] == site_selected].iloc[0]
         lon, lat = row["LON"], row["LAT"]
-        center = (lon, lat)
 
-        # Create GeoSeries
-        point = Point(lon, lat)
-        buffer = gpd.GeoSeries([point], crs='EPSG:4326').to_crs(epsg=3857).buffer(radius)
+        m = folium.Map(location=[lat, lon], zoom_start=16, tiles="cartodbpositron")
 
-        fig, ax = plt.subplots(figsize=(8,8))
+        # Impact zone as a red circle
+        folium.Circle(
+            location=[lat, lon],
+            radius=radius,
+            color="darkred",
+            fill=True,
+            fill_color="red",
+            fill_opacity=0.4,
+        ).add_to(m)
 
-        # black & white base
-        buffer.to_crs(epsg=4326).plot(ax=ax, color='red', alpha=0.4, edgecolor='darkred', label='Impact Zone')
-        gpd.GeoSeries([point], crs='EPSG:4326').plot(ax=ax, color='blue', marker='*', markersize=100, label='Entrance')
+        # Entrance marker with star icon
+        folium.Marker(
+            location=[lat, lon],
+            tooltip="Entrance",
+            icon=folium.Icon(color="red", icon="star", prefix="fa"),
+        ).add_to(m)
 
-        ax.annotate("School Entrance", xy=(lon, lat), xytext=(lon+0.001, lat+0.001),
-                    arrowprops=dict(facecolor='black', arrowstyle="->"), fontsize=9)
+        st_data = st_folium(m, width=700, height=500)
 
-        plt.axis('off')
-        plt.title(f"Construction Impact Map – {site_selected}", fontsize=12)
+        # Optional export of the map as HTML and PNG (requires selenium)
+        html_data = m.get_root().render()
+        st.download_button(
+            "Download HTML", data=html_data,
+            file_name=f"{site_selected.replace(' ', '_')}.html", mime="text/html"
+        )
 
-        from io import BytesIO
-        buf = BytesIO()
-        plt.savefig(buf, format="png", dpi=300, bbox_inches='tight')
-        buf.seek(0)
-
-        st.pyplot(fig)
-        st.download_button("Download PNG", data=buf, file_name=f"{site_selected.replace(' ','_')}_impact_map.png", mime="image/png")
+        try:
+            png_data = m._to_png(5)
+            st.download_button(
+                "Download PNG", data=png_data,
+                file_name=f"{site_selected.replace(' ', '_')}.png", mime="image/png"
+            )
+        except Exception as e:
+            st.info("PNG export requires selenium and a compatible web driver.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ matplotlib
 shapely
 prettymapp
 pandas
+folium
+streamlit-folium


### PR DESCRIPTION
## Summary
- replace matplotlib rendering with interactive Folium map
- add CartoDB Positron base layer and entrance marker
- allow optional download of map as HTML or PNG
- include folium dependencies

## Testing
- `python -m py_compile app.py`
- `pytest`